### PR TITLE
Add playground block

### DIFF
--- a/gutenberg-extensibility-workshop.php
+++ b/gutenberg-extensibility-workshop.php
@@ -7,6 +7,7 @@
  */
 
 require_once dirname( __FILE__ ) . '/lib/common.php';
+require_once dirname( __FILE__ ) . '/lib/00-playground.php';
 require_once dirname( __FILE__ ) . '/lib/01-intro-block.php';
 require_once dirname( __FILE__ ) . '/lib/02-static-block.php';
 require_once dirname( __FILE__ ) . '/lib/03-advanced-static-block.php';

--- a/lib/00-playground.php
+++ b/lib/00-playground.php
@@ -1,0 +1,17 @@
+<?php
+
+function register_00_playground() {
+	// Register the block script
+	wp_register_script(
+		'gew-00-playground',
+		gew_url( 'scripts/00-playground/index.js', __FILE__ ),
+		array( 'wp-blocks', 'wp-element', 'wp-plugins' )
+	);
+
+	// Attach the script to the block
+	register_block_type( 'gew/playground', array(
+		'editor_script' => 'gew-00-playground',
+	) );
+}
+
+add_action( 'init', 'register_00_playground' );

--- a/scripts/00-playground/index.js
+++ b/scripts/00-playground/index.js
@@ -1,0 +1,36 @@
+var registerBlockType = wp.blocks.registerBlockType;
+var el = wp.element.createElement;
+
+registerBlockType("gew/playground", {
+  // Title of the block.
+  title: "00 - Playground",
+
+  // Icon of the block dashicon string (https://developer.wordpress.org/resource/dashicons) or custom svg element.
+  icon: "welcome-learn-more",
+
+  // Category (common, formatting, layout, widgets, embed)
+  category: "common",
+
+  // Description of the block
+  description: "This block introduces you to block creation",
+
+  // Keywords to search for the block
+  keywords: ["learn", "gutenberg"],
+
+  // Block's editor representation
+  edit: function(props) {
+    return el("p", { className: props.className }, "Welcome to Gutenberg");
+  },
+
+  // Block's frontend representation
+  save: function() {
+    return el("p", {}, "Welcome to Gutenberg");
+  }
+});
+
+var registerPlugin = wp.plugins.registerPlugin;
+registerPlugin("gew/playground", {
+  render: function() {
+    return null;
+  }
+});


### PR DESCRIPTION
For attendees to follow along, the simplest block stub to start from such that they can edit from their admin's Editor screen without modifying original copies of the examples.