### PR TITLE
Enqueue all scripts at admin enqueue actions

### DIFF
--- a/lib/06-post-status-info-plugin.php
+++ b/lib/06-post-status-info-plugin.php
@@ -1,11 +1,15 @@
 <?php
 
-wp_enqueue_script(
-	'gew-06-post-status-info-plugin',
-	gew_url( 'scripts/06-post-status-info-plugin/index.es5.js', __FILE__ ),
-	array(
-		'wp-edit-post',
-		'wp-element',
-		'wp-plugins',
-	)
-);
+function register_06_post_status_info_plugin() {
+	wp_enqueue_script(
+		'gew-06-post-status-info-plugin',
+		gew_url( 'scripts/06-post-status-info-plugin/index.es5.js', __FILE__ ),
+		array(
+			'wp-edit-post',
+			'wp-element',
+			'wp-plugins',
+		)
+	);
+}
+
+add_action( 'admin_enqueue_scripts', 'register_06_post_status_info_plugin' );

--- a/lib/07-publish-panel-plugin.php
+++ b/lib/07-publish-panel-plugin.php
@@ -1,11 +1,15 @@
 <?php
 
-wp_enqueue_script(
-	'gew-07-publish-panel-plugin',
-	gew_url( 'scripts/07-publish-panel-plugin/index.es5.js', __FILE__ ),
-	array(
-		'wp-edit-post',
-		'wp-element',
-		'wp-plugins',
-	)
-);
+function register_07_publish_panel_plugin() {
+	wp_enqueue_script(
+		'gew-07-publish-panel-plugin',
+		gew_url( 'scripts/07-publish-panel-plugin/index.es5.js', __FILE__ ),
+		array(
+			'wp-edit-post',
+			'wp-element',
+			'wp-plugins',
+		)
+	);
+}
+
+add_action( 'admin_enqueue_scripts', 'register_07_publish_panel_plugin' );

--- a/lib/08-sidebar-plugin.php
+++ b/lib/08-sidebar-plugin.php
@@ -1,14 +1,18 @@
 <?php
 
-wp_enqueue_script(
-	'gew-08-sidebar-plugin',
-	gew_url( 'scripts/08-sidebar-plugin/index.es5.js', __FILE__ ),
-	array(
-		'wp-components',
-		'wp-data',
-		'wp-edit-post',
-		'wp-editor',
-		'wp-element',
-		'wp-plugins',
-	)
-);
+function register_08_sidebar_plugin() {
+	wp_enqueue_script(
+		'gew-08-sidebar-plugin',
+		gew_url( 'scripts/08-sidebar-plugin/index.es5.js', __FILE__ ),
+		array(
+			'wp-components',
+			'wp-data',
+			'wp-edit-post',
+			'wp-editor',
+			'wp-element',
+			'wp-plugins',
+		)
+	);
+}
+
+add_action( 'admin_enqueue_scripts', 'register_08_sidebar_plugin' );


### PR DESCRIPTION
Resolves warnings.

>Notice:  wp_enqueue_script was called incorrectly. Scripts and styles should not be registered or enqueued until the wp_enqueue_scripts, admin_enqueue_scripts, or login_enqueue_scripts hooks. Please see Debugging in WordPress for more information. (This message was added in version 3.3.0.) in /srv/www/editor/htdocs/wp-includes/functions.php on line 4148