### PR TITLE
Set static block example default alert type to default

### DIFF
--- a/scripts/02-static-block/index.es5.js
+++ b/scripts/02-static-block/index.es5.js
@@ -10,7 +10,7 @@ registerBlockType("gew/static-block", {
   attributes: {
     type: {
       type: "string",
-      default: "danger"
+      default: "default"
     },
     message: {
       type: "string",


### PR DESCRIPTION
There is no danger styling. May be misleading.