### PR TITLE
Build fails due to missing scss file

### DIFF
--- a/scripts/09-sidebar-plugin/index.js
+++ b/scripts/09-sidebar-plugin/index.js
@@ -14,7 +14,7 @@ import { PluginSidebarMoreMenuItem, PluginSidebar } from "@wordpress/editPost";
 
 import { Fragment } from "@wordpress/element";
 
-import "./style.scss";
+import "./style.css";
 
 // Component showing the menu item
 const BlockTypesMoreMenuItem = () => (


### PR DESCRIPTION
``
ERROR in ./scripts/09-sidebar-plugin/index.js
Module not found: Error: Can't resolve './style.scss' in '.../wordpress/app/build/wp-content/gew/scripts/09-sidebar-plugin'
 @ ./scripts/09-sidebar-plugin/index.js 18:0-22
``
Changed the .scss to .css to make the build succeed.