### PR TITLE
Change import from scss to css

### DIFF
--- a/scripts/09-sidebar-plugin/index.js
+++ b/scripts/09-sidebar-plugin/index.js
@@ -14,7 +14,7 @@ import { PluginSidebarMoreMenuItem, PluginSidebar } from "@wordpress/editPost";
 
 import { Fragment } from "@wordpress/element";
 
-import "./style.scss";
+import "./style.css";
 
 // Component showing the menu item
 const BlockTypesMoreMenuItem = () => (


### PR DESCRIPTION
Stylesheet was changed from scss to css.
see https://github.com/youknowriad/gutenberg-extensibility-workshop/commit/29491a912f4918a29e1026c41faf4aab5103723e